### PR TITLE
Fix height of the resetText for the custom input.

### DIFF
--- a/src/render.zig
+++ b/src/render.zig
@@ -158,8 +158,10 @@ pub fn resetText(bar: *Bar) !void {
     if (buffer.buffer == null) return;
     buffer.busy = true;
 
+    const text_to_bottom: u16 =
+        @intCast(state.config.font.height + bar.text_padding);
     const bg_area = [_]pixman.Rectangle16{
-        .{ .x = 0, .y = 0, .width = bar.text_width, .height = bar.height },
+        .{ .x = 0, .y = 0, .width = bar.text_width, .height = text_to_bottom },
     };
     var bg_color = state.config.normalBgColor;
     _ = pixman.Image.fillRectangles(.src, buffer.pix.?, &bg_color, 1, &bg_area);


### PR DESCRIPTION
The repaint of the custom data was not set correctly. The region was too large and an artifact appeared when switching from a monitor to another.

![fault1](https://github.com/user-attachments/assets/38793450-d9fd-46ff-9502-30afaeb65c61)

Here I've put the painted region in green, so we can see better:
![paintedRegion](https://github.com/user-attachments/assets/26d36793-291a-438f-8b14-64498c736f4f)

Here is the result of the new painted area:
![newRegion](https://github.com/user-attachments/assets/0df18fc2-5782-40e3-9306-816b4208cb24)


And this is the final result:
![final](https://github.com/user-attachments/assets/7f07a946-ec19-48d5-9b13-393910b67126)

The cause was the height of the bar was taken without any regards of the padding whatsoever. Now the region is calculated based on the height of the font + the padding.


Cheers