### PR TITLE
Seat: add option to show statustext on all outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = {
+        nixpkgs,
+        flake-utils,
+        ...
+    }: flake-utils.lib.eachSystem ["x86_64-linux"] (system:
+        let
+            pkgs = import nixpkgs {
+                inherit system;
+            };
+
+            slstatus = (with pkgs; stdenv.mkDerivation rec {
+                pname = "creek";
+                version = "4.3";
+
+                src = ./.;
+               
+                nativeBuildInputs = [
+                    zig.hook
+                    pkg-config
+                    wayland-scanner
+                ];
+                buildInputs = [
+                    fcft
+                    pixman
+                    wayland
+                    wayland-protocols
+                ];
+               
+                deps = pkgs.linkFarm "zig-packages" [
+                    {
+                        name = "fcft-2.0.0-zcx6C5EaAADIEaQzDg5D4UvFFMjSEwDE38vdE9xObeN9";
+                        path = fetchzip {
+                          url = "https://git.sr.ht/~novakane/zig-fcft/archive/v2.0.0.tar.gz";
+                          hash = "sha256-qDEtiZNSkzN8jUSnZP/itqh8rMf+lakJy4xMB0I8sxQ=";
+                        };
+                    }
+                    {
+                        name = "pixman-0.3.0-LClMnz2VAAAs7QSCGwLimV5VUYx0JFnX5xWU6HwtMuDX";
+                        path = fetchzip {
+                            url = "https://codeberg.org/ifreund/zig-pixman/archive/v0.3.0.tar.gz";
+                            hash = "sha256-8tA4auo5FEI4IPnomV6bkpQHUe302tQtorFQZ1l14NU=";
+                        };
+                    }
+                    {
+                        name = "wayland-0.3.0-lQa1kjPIAQDmhGYpY-zxiRzQJFHQ2VqhJkQLbKKdt5wl";
+                        path = fetchzip {
+                            url = "https://codeberg.org/ifreund/zig-wayland/archive/v0.3.0.tar.gz";
+                            hash = "sha256-ydEavD9z20wRwn9ZVX56ZI2T5i1tnm3LupVxfa30o84=";
+                        };
+                    }
+                ];
+
+                zigBuildFlags = [
+                    "--system"
+                    "${deps}"
+                ];
+            });
+        in {
+          defaultPackage = slstatus;
+        }
+    );
+}

--- a/src/Seat.zig
+++ b/src/Seat.zig
@@ -131,11 +131,22 @@ fn unfocusedOutput(self: *Seat, output: *wl.Output) void {
 
     if (monitor) |m| {
         if (m.confBar()) |bar| {
-            render.resetText(bar) catch |err| {
-                log.err("resetText failed for monitor {}: {s}",
-                    .{bar.monitor.globalName, @errorName(err)});
-            };
-            bar.text.surface.commit();
+            renderText: {
+                if (!state.config.showStatusAllOutputs) {
+                    render.resetText(bar) catch |err| {
+                        log.err("resetText failed for monitor {}: {s}",
+                            .{bar.monitor.globalName, @errorName(err)});
+                        break :renderText;
+                    };
+                } else {
+                    render.renderText(bar, self.status_text.getWritten()) catch |err| {
+                        log.err("renderTexk failed on unfocused monitor {}: {s}",
+                            .{m.globalName, @errorName(err)});
+                        break :renderText;
+                    };
+                }
+                bar.text.surface.commit();
+            }
 
             render.renderTitle(bar, null) catch |err| {
                 log.err("renderTitle failed on unfocus for monitor {}: {s}",

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -44,7 +44,7 @@ pub fn parser(comptime Arg: type, comptime flags: []const Flag) type {
                         .boolean => .{
                             .name = flag.name,
                             .type = bool,
-                            .default_value = &false,
+                            .default_value_ptr = &false,
                             .is_comptime = false,
                             .alignment = @alignOf(bool),
                         },

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,7 @@ pub const Config = struct {
     focusFgColor: pixman.Color,
     focusBgColor: pixman.Color,
     font: *fcft.Font,
+    showStatusAllOutputs: bool,
 };
 
 pub const State = struct {
@@ -66,6 +67,7 @@ fn parseFlags(args: [][*:0]u8) !Config {
         .{ .name = "nb", .kind = .arg }, // normal background
         .{ .name = "ff", .kind = .arg }, // focused foreground
         .{ .name = "fb", .kind = .arg }, // focused background
+        .{ .name = "sao", .kind = .boolean }, // show statustext on all outputs
     }).parse(args) catch {
         usage();
     };
@@ -90,13 +92,14 @@ fn parseFlags(args: [][*:0]u8) !Config {
         .normalBgColor = try parseColorFlag(result.flags.nb, "0x282828"),
         .focusFgColor = try parseColorFlag(result.flags.ff, "0x181818"),
         .focusBgColor = try parseColorFlag(result.flags.fb, "0x7cafc2"),
+        .showStatusAllOutputs = result.flags.sao,
     };
 }
 
 pub fn usage() noreturn {
     const desc =
         \\usage: creek [-hg HEIGHT] [-fn FONT] [-nf COLOR] [-nb COLOR]
-        \\             [-ff COLOR] [-fb COLOR]
+        \\             [-ff COLOR] [-fb COLOR] [ -sao ] Show statustext on all outputs
         \\
     ;
 


### PR DESCRIPTION
Add a cli option (-sao) to show the read statustext on all outputs, not just the active one.
Updates the boolean option parsing as well to fit with new zig standardlibrary updates.

I'm giving you the flake I used for development too, somebody probably needs it...

Tested with slstatus.